### PR TITLE
Fixes issue where it's impossible to override shouldRecognizeSimultaneouslyWith

### DIFF
--- a/TBEmptyDataSet/TBEmptyDataSet.swift
+++ b/TBEmptyDataSet/TBEmptyDataSet.swift
@@ -182,7 +182,7 @@ extension UIScrollView: UIGestureRecognizerDelegate {
         return super.gestureRecognizerShouldBegin(gestureRecognizer)
     }
 
-    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+    open func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         if let emptyDataView = emptyDataView, gestureRecognizer == emptyDataView.tapGesture || otherGestureRecognizer == emptyDataView.tapGesture {
             return true
         }


### PR DESCRIPTION
`gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool`

was impossible to override after adding your pod because it's declared in `TBEmptyDataSet.swift` as `public` instead of `open`